### PR TITLE
COMP: Fix macOS linking

### DIFF
--- a/SuperBuild/External_vtkRenderingLookingGlass.cmake
+++ b/SuperBuild/External_vtkRenderingLookingGlass.cmake
@@ -36,6 +36,13 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
       )
   endif()
 
+  if(APPLE)
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+      # Workaround https://gitlab.kitware.com/vtk/vtk/-/issues/18032
+      -DVTK_USE_COCOA:BOOL=ON
+      )
+  endif()
+
   ExternalProject_SetIfNotDefined(
     ${SUPERBUILD_TOPLEVEL_PROJECT}_${proj}_GIT_REPOSITORY
     "${EP_GIT_PROTOCOL}://github.com/jcfr/LookingGlassVTKModule.git"


### PR DESCRIPTION
This commit works around issue https://gitlab.kitware.com/vtk/vtk/-/issues/18032
and fixes the following link error:

```
  [ 14%] Linking CXX shared library /Users/jcfr/Projects/SLG-rwdi/lib/Slicer-4.13/libvtkRenderingLookingGlass.dylib
  Undefined symbols for architecture x86_64:
    "vtkCocoaLookingGlassRenderWindow::SetLGDeviceIndex(int)", referenced from:
        vtkLookingGlassInterface::CreateLookingGlassRenderWindow(int) in vtkLookingGlassInterface.cxx.o
    "vtkCocoaLookingGlassRenderWindow::New()", referenced from:
        vtkLookingGlassInterface::CreateLookingGlassRenderWindow(int) in vtkLookingGlassInterface.cxx.o
  ld: symbol(s) not found for architecture x86_64
  clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Fixes #2

Co-authored-by: Samuel Gerber <samuel.gerber@kitware.com>