### PR TITLE
BUG: Fix crash in registering markups displ. man. when connecting to device

### DIFF
--- a/LookingGlass/Widgets/qMRMLLookingGlassView.cxx
+++ b/LookingGlass/Widgets/qMRMLLookingGlassView.cxx
@@ -194,6 +194,14 @@ void qMRMLLookingGlassViewPrivate::createRenderWindow()
   vtkMRMLLookingGlassViewDisplayableManagerFactory* factory
     = vtkMRMLLookingGlassViewDisplayableManagerFactory::GetInstance();
 
+  vtkSlicerApplicationLogic* appLogic = qSlicerApplication::application()->applicationLogic();
+  if (!appLogic)
+  {
+    qCritical() << Q_FUNC_INFO << ": Failed to access application logic";
+    return;
+  }
+  factory->SetMRMLApplicationLogic(appLogic);
+
   QStringList displayableManagers;
   displayableManagers
       << "vtkMRMLCameraDisplayableManager"


### PR DESCRIPTION
When registering the markups displayable manager, and then it creates widgets for the existing markups, it wants to use the application logic to get the markups logic, which it is supposed to get from the factory, but since in the factory it was not set, getting the markups logic failed in absence of the application logic and it caused a crash. Fixed by setting the application logic directly.