### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(SlicerLookingGlass)
 set(EXTENSION_HOMEPAGE "https://github.com/KitwareMedical/SlicerLookingGlass")
 set(EXTENSION_CATEGORY "Holographic Display")
 set(EXTENSION_CONTRIBUTORS "Jean-Christophe Fillion-Robin (Kitware), Ken Martin (Kitware), Cory Quammen (Kitware), Andras Lasso (PerkLab)")
-set(EXTENSION_DESCRIPTION "Allows user to visualize the 3D scene using the Looking Glass hardware display.")
+set(EXTENSION_DESCRIPTION "Enables user to visualize the 3D scene using the Looking Glass hardware display.")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/KitwareMedical/SlicerLookingGlass/master/LookingGlass/Resources/Icons/LookingGlass.png")
 set(EXTENSION_SCREENSHOTURLS "https://github.com/KitwareMedical/SlicerLookingGlass/releases/download/docs-resources/2020.09.24_SlicerLookingGlass_WhiteMatterAnalysis.png")
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.