### PR TITLE
Extension updated for newer versions of slicer

### DIFF
--- a/FetchVTKRenderingLookingGlass.cmake
+++ b/FetchVTKRenderingLookingGlass.cmake
@@ -5,8 +5,8 @@ if(NOT DEFINED vtkRenderingLookingGlass_SOURCE_DIR)
   set(EP_SOURCE_DIR "${CMAKE_BINARY_DIR}/${proj}")
   FetchContent_Populate(${proj}
     SOURCE_DIR     ${EP_SOURCE_DIR}
-    GIT_REPOSITORY https://github.com/KitwareMedical/LookingGlassVTKModule.git
-    GIT_TAG        23cd56032165848c60739898ccf613e35cbde62d  # slicer-20221024-78cc2ce
+    GIT_REPOSITORY https://github.com/Kitware/LookingGlassVTKModule
+    GIT_TAG        145e306d2f46808713d5b2b930ee5acbd6096a3e
     QUIET
     )
   message(STATUS "Remote - ${proj} [OK]")

--- a/FetchVTKRenderingLookingGlass.cmake
+++ b/FetchVTKRenderingLookingGlass.cmake
@@ -5,8 +5,8 @@ if(NOT DEFINED vtkRenderingLookingGlass_SOURCE_DIR)
   set(EP_SOURCE_DIR "${CMAKE_BINARY_DIR}/${proj}")
   FetchContent_Populate(${proj}
     SOURCE_DIR     ${EP_SOURCE_DIR}
-    GIT_REPOSITORY https://github.com/Kitware/LookingGlassVTKModule
-    GIT_TAG        145e306d2f46808713d5b2b930ee5acbd6096a3e
+    GIT_REPOSITORY https://github.com/cpinter/LookingGlassVTKModule
+    GIT_TAG        6bf773497d661f49fe3e63e3f9c0f8f737510ca2
     QUIET
     )
   message(STATUS "Remote - ${proj} [OK]")

--- a/LookingGlass/Logic/vtkSlicerLookingGlassLogic.cxx
+++ b/LookingGlass/Logic/vtkSlicerLookingGlassLogic.cxx
@@ -227,6 +227,27 @@ void vtkSlicerLookingGlassLogic::SetLookingGlassConnected(bool connect)
     if (this->ActiveViewNode)
       {
       this->ActiveViewNode->SetVisibility(1);
+
+      // Always set the reference view node to the first visible 3D view node
+      vtkMRMLScene* scene = this->GetMRMLScene();
+      if (scene)
+        {
+        vtkSmartPointer<vtkCollection> nodes = vtkSmartPointer<vtkCollection>::Take(
+            scene->GetNodesByClass("vtkMRMLViewNode"));
+        vtkMRMLViewNode* viewNode = nullptr;
+        vtkCollectionSimpleIterator it;
+        for (nodes->InitTraversal(it); (viewNode = vtkMRMLViewNode::SafeDownCast(
+                                          nodes->GetNextItemAsObject(it)));)
+          {
+          if (viewNode->GetVisibility() && viewNode->IsMappedInLayout())
+            {
+            // Found a view node displayed in current layout, use this
+            break;
+            }
+          }
+        // Either use a view node displayed in current layout or just any 3D view node found in the scene
+        this->ActiveViewNode->SetAndObserveReferenceViewNode(viewNode);
+        }
       }
     else
       {

--- a/LookingGlass/MRML/vtkMRMLLookingGlassViewDisplayableManagerFactory.cxx
+++ b/LookingGlass/MRML/vtkMRMLLookingGlassViewDisplayableManagerFactory.cxx
@@ -25,40 +25,6 @@
 #include <vtkObjectFactory.h>
 
 //----------------------------------------------------------------------------
-// vtkMRMLLookingGlassViewDisplayableManagerFactory methods
-
-//----------------------------------------------------------------------------
-// Up the reference count so it behaves like New
-vtkMRMLLookingGlassViewDisplayableManagerFactory* vtkMRMLLookingGlassViewDisplayableManagerFactory::New()
-{
-  vtkMRMLLookingGlassViewDisplayableManagerFactory* instance = Self::GetInstance();
-  instance->Register(0);
-  return instance;
-}
-
-//----------------------------------------------------------------------------
-vtkMRMLLookingGlassViewDisplayableManagerFactory* vtkMRMLLookingGlassViewDisplayableManagerFactory::GetInstance()
-{
-  if(!Self::Instance)
-    {
-    // Try the factory first
-    Self::Instance = (vtkMRMLLookingGlassViewDisplayableManagerFactory*)
-                     vtkObjectFactory::CreateInstance("vtkMRMLLookingGlassViewDisplayableManagerFactory");
-
-    // if the factory did not provide one, then create it here
-    if(!Self::Instance)
-      {
-      Self::Instance = new vtkMRMLLookingGlassViewDisplayableManagerFactory;
-#ifdef VTK_HAS_INITIALIZE_OBJECT_BASE
-      Self::Instance->InitializeObjectBase();
-#endif
-      }
-    }
-  // return the instance
-  return Self::Instance;
-}
-
-//----------------------------------------------------------------------------
 vtkMRMLLookingGlassViewDisplayableManagerFactory::
     vtkMRMLLookingGlassViewDisplayableManagerFactory():Superclass()
 {

--- a/LookingGlass/Widgets/qMRMLLookingGlassView.cxx
+++ b/LookingGlass/Widgets/qMRMLLookingGlassView.cxx
@@ -167,16 +167,18 @@ void qMRMLLookingGlassViewPrivate::createRenderWindow()
   this->LastViewPosition[1] = 0.0;
   this->LastViewPosition[2] = 0.0;
 
-  this->RenderWindow = vtkSmartPointer<vtkOpenGLRenderWindow>::Take(
-        vtkLookingGlassInterface::CreateLookingGlassRenderWindow());
-
-  this->Renderer = vtkSmartPointer<vtkRenderer>::New();
+  // Create render window interactor
   this->Interactor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+  this->RenderWindow->SetInteractor(this->Interactor);
+
+  // Create MRML interactor style
   this->InteractorStyle = vtkSmartPointer<vtkMRMLThreeDViewInteractorStyle>::New();
 
-  this->Interactor->SetInteractorStyle(this->InteractorStyle);
+  // Attach it to the interactor
   this->InteractorStyle->SetInteractor(this->Interactor);
-  this->InteractorStyle->SetCurrentRenderer(this->Renderer);
+
+  // Do NOT call SetCurrentRenderer (not available anymore)
+  // Do NOT call Interactor->SetInteractorStyle(this->InteractorStyle) either
 
   this->Camera = vtkSmartPointer<vtkCamera>::New();
   this->Renderer->SetActiveCamera(this->Camera);


### PR DESCRIPTION
This PR updates the extension to work with the newer versions of Slicer.

1. Fixes problem in build with vtkMRMLLookingGlassViewDisplayableManagerFactory and vtkSingleton. 
2. SetCurrentRenderer call removed as it is not available anymore.
3. Fixes Renderer being nullptr when trying to connect to LookingGlass device.
4. When setting up LookingGlass connection makes the reference view the 3D by default.