### PR TITLE
COMP: Fix extension with latest Slicer; Support new devices

### DIFF
--- a/FetchVTKRenderingLookingGlass.cmake
+++ b/FetchVTKRenderingLookingGlass.cmake
@@ -5,8 +5,8 @@ if(NOT DEFINED vtkRenderingLookingGlass_SOURCE_DIR)
   set(EP_SOURCE_DIR "${CMAKE_BINARY_DIR}/${proj}")
   FetchContent_Populate(${proj}
     SOURCE_DIR     ${EP_SOURCE_DIR}
-    GIT_REPOSITORY https://github.com/KitwareMedical/LookingGlassVTKModule.git
-    GIT_TAG        23cd56032165848c60739898ccf613e35cbde62d  # slicer-20221024-78cc2ce
+    GIT_REPOSITORY https://github.com/cpinter/LookingGlassVTKModule
+    GIT_TAG        fd2b4611c28f2d019deaaeef58df8b35d44d7698
     QUIET
     )
   message(STATUS "Remote - ${proj} [OK]")

--- a/LookingGlass/Logic/vtkSlicerLookingGlassLogic.cxx
+++ b/LookingGlass/Logic/vtkSlicerLookingGlassLogic.cxx
@@ -227,6 +227,27 @@ void vtkSlicerLookingGlassLogic::SetLookingGlassConnected(bool connect)
     if (this->ActiveViewNode)
       {
       this->ActiveViewNode->SetVisibility(1);
+
+      // Always set the reference view node to the first visible 3D view node
+      vtkMRMLScene* scene = this->GetMRMLScene();
+      if (scene)
+        {
+        vtkSmartPointer<vtkCollection> nodes = vtkSmartPointer<vtkCollection>::Take(
+            scene->GetNodesByClass("vtkMRMLViewNode"));
+        vtkMRMLViewNode* viewNode = nullptr;
+        vtkCollectionSimpleIterator it;
+        for (nodes->InitTraversal(it); (viewNode = vtkMRMLViewNode::SafeDownCast(
+                                          nodes->GetNextItemAsObject(it)));)
+          {
+          if (viewNode->GetVisibility() && viewNode->IsMappedInLayout())
+            {
+            // Found a view node displayed in current layout, use this
+            break;
+            }
+          }
+        // Either use a view node displayed in current layout or just any 3D view node found in the scene
+        this->ActiveViewNode->SetAndObserveReferenceViewNode(viewNode);
+        }
       }
     else
       {

--- a/LookingGlass/MRML/vtkMRMLLookingGlassViewDisplayableManagerFactory.cxx
+++ b/LookingGlass/MRML/vtkMRMLLookingGlassViewDisplayableManagerFactory.cxx
@@ -25,40 +25,6 @@
 #include <vtkObjectFactory.h>
 
 //----------------------------------------------------------------------------
-// vtkMRMLLookingGlassViewDisplayableManagerFactory methods
-
-//----------------------------------------------------------------------------
-// Up the reference count so it behaves like New
-vtkMRMLLookingGlassViewDisplayableManagerFactory* vtkMRMLLookingGlassViewDisplayableManagerFactory::New()
-{
-  vtkMRMLLookingGlassViewDisplayableManagerFactory* instance = Self::GetInstance();
-  instance->Register(0);
-  return instance;
-}
-
-//----------------------------------------------------------------------------
-vtkMRMLLookingGlassViewDisplayableManagerFactory* vtkMRMLLookingGlassViewDisplayableManagerFactory::GetInstance()
-{
-  if(!Self::Instance)
-    {
-    // Try the factory first
-    Self::Instance = (vtkMRMLLookingGlassViewDisplayableManagerFactory*)
-                     vtkObjectFactory::CreateInstance("vtkMRMLLookingGlassViewDisplayableManagerFactory");
-
-    // if the factory did not provide one, then create it here
-    if(!Self::Instance)
-      {
-      Self::Instance = new vtkMRMLLookingGlassViewDisplayableManagerFactory;
-#ifdef VTK_HAS_INITIALIZE_OBJECT_BASE
-      Self::Instance->InitializeObjectBase();
-#endif
-      }
-    }
-  // return the instance
-  return Self::Instance;
-}
-
-//----------------------------------------------------------------------------
 vtkMRMLLookingGlassViewDisplayableManagerFactory::
     vtkMRMLLookingGlassViewDisplayableManagerFactory():Superclass()
 {

--- a/LookingGlass/Widgets/qMRMLLookingGlassView.cxx
+++ b/LookingGlass/Widgets/qMRMLLookingGlassView.cxx
@@ -167,29 +167,42 @@ void qMRMLLookingGlassViewPrivate::createRenderWindow()
   this->LastViewPosition[1] = 0.0;
   this->LastViewPosition[2] = 0.0;
 
-  this->RenderWindow = vtkSmartPointer<vtkOpenGLRenderWindow>::Take(
-        vtkLookingGlassInterface::CreateLookingGlassRenderWindow());
+  // Ensure render window exists
+  if (!this->RenderWindow)
+  {
+    this->RenderWindow = vtkSmartPointer<vtkWin32LookingGlassRenderWindow>::New();
+  }
 
-  this->Renderer = vtkSmartPointer<vtkRenderer>::New();
+  // Create render window interactor
   this->Interactor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
-  this->InteractorStyle = vtkSmartPointer<vtkMRMLThreeDViewInteractorStyle>::New();
-
-  this->Interactor->SetInteractorStyle(this->InteractorStyle);
-  this->InteractorStyle->SetInteractor(this->Interactor);
-  this->InteractorStyle->SetCurrentRenderer(this->Renderer);
-
-  this->Camera = vtkSmartPointer<vtkCamera>::New();
-  this->Renderer->SetActiveCamera(this->Camera);
-  this->RenderWindow->SetMultiSamples(0);
-  this->RenderWindow->AddRenderer(this->Renderer);
   this->RenderWindow->SetInteractor(this->Interactor);
 
-  // The interactor never calls Render() on the render window.
+  // Create MRML interactor style
+  this->InteractorStyle = vtkSmartPointer<vtkMRMLThreeDViewInteractorStyle>::New();
+
+  if (this->Interactor && this->InteractorStyle)
+  {
+    this->InteractorStyle->SetInteractor(this->Interactor);
+  }
+
+  // Now safe to continue
+  this->Camera = vtkSmartPointer<vtkCamera>::New();
+
+  if (!this->Renderer)
+  {
+    this->Renderer = vtkSmartPointer<vtkRenderer>::New();
+    this->Renderer->SetBackground(0.1, 0.1, 0.1);
+    this->Renderer->SetActiveCamera(this->Camera);
+    this->RenderWindow->SetMultiSamples(0);
+    this->RenderWindow->AddRenderer(this->Renderer);  // attach renderer to window
+  }
+
+  // Interactor already attached above, no need to repeat
   this->Interactor->SetEnableRender(false);
 
   // Ensure this view catches all render requests and ensure the desired framerate
   this->qvtkReconnect(this->RenderWindow->GetInteractor(), this->Interactor,
-                vtkCommand::RenderEvent, q, SLOT(scheduleRender()));
+                  vtkCommand::RenderEvent, q, SLOT(scheduleRender()));
 
   vtkMRMLLookingGlassViewDisplayableManagerFactory* factory
     = vtkMRMLLookingGlassViewDisplayableManagerFactory::GetInstance();


### PR DESCRIPTION
This PR updates the extension to work with the newer versions of Slicer.
1. Fixes problem in build with `vtkMRMLLookingGlassViewDisplayableManagerFactory` and `vtkSingleton`.
2. `SetCurrentRenderer` call removed as it is not available anymore.
3. Fixes Renderer being `nullptr` when trying to connect to Looking Glass device.
4. When setting up Looking Glass connection makes the reference view the 3D by default.
5. Update [LookingGlassVTKModule](https://github.com/Kitware/LookingGlassVTKModule) to support new devices

This latest change will need to follow the integration of https://github.com/Kitware/LookingGlassVTKModule/pull/72

Supersedes https://github.com/KitwareMedical/SlicerLookingGlass/pull/29